### PR TITLE
code-splitting in build though `() => import(...)`

### DIFF
--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -1,56 +1,53 @@
-import { createRouter, createWebHistory } from 'vue-router';
-import Account from "@/views/Account.vue";
-import Annotations from '../views/Annotations.vue';
-import Annotator from '../views/Annotator.vue';
-import Criteria from '../views/Criteria.vue';
-import Dashboard from '../views/Dashboard.vue';
-import Dataset from '../views/Dataset.vue';
-import Definitions from '../views/Definitions.vue';
-import NotFound from "../views/404.vue";
+import {createRouter, createWebHashHistory} from 'vue-router';
 
 
+// `() => import(...)` for code splitting
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  // we only have one index.html file so WebHashHistory reduces problems with configuring the proxy-server
+  // https://domain.com/path
+  // history: createWebHistory(import.meta.env.BASE_URL),
+  // https://domain.com/#/path
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',
       name: 'Dashboard',
-      component: Dashboard,
+      component: () => import("@/views/Dashboard.vue"),
     },
     {
       path: '/account/:username',
       name: 'Account',
-      component: Account,
+      component: () => import("@/views/Account.vue"),
     },
     {
       path: '/annotations',
       name: 'Annotations',
-      component: Annotations,
+      component: () => import("@/views/Annotations.vue"),
     },
     {
       path: '/annotator',
       name: 'Annotator',
-      component: Annotator,
+      component: () => import("@/views/Annotator.vue"),
     },
     {
       path: '/:datasetName/criteria',
       name: 'Criteria',
-      component: Criteria,
+      component: () => import("@/views/Criteria.vue"),
     },
     {
       path: '/dataset/:datasetName',
       name: 'Dataset',
-      component: Dataset,
+      component: () => import("@/views/Dataset.vue"),
     },
     {
       path: '/definitions',
       name: 'Definitions',
-      component: Definitions,
+      component: () => import("@/views/Definitions.vue"),
     },
     {
       path: "/:pathMatch(.*)*",
       name: 'NotFound',
-      component: NotFound,
+      component: () => import("@/views/404.vue"),
     },
   ]
 });


### PR DESCRIPTION
without splitting
```
dist/index.html                   0.43 kB │ gzip:  0.28 kB
dist/assets/logo-affe5bea.svg     1.94 kB │ gzip:  0.75 kB
dist/assets/index-a8753a21.css    9.92 kB │ gzip:  2.73 kB
dist/assets/index-7ae23c2a.js   165.55 kB │ gzip: 61.83 kB
```
with splitting
```
dist/index.html                                                       0.43 kB │ gzip:  0.29 kB
dist/assets/logo-affe5bea.svg                                         1.94 kB │ gzip:  0.75 kB
dist/assets/index-a8753a21.css                                        9.92 kB │ gzip:  2.73 kB
dist/assets/Annotator-aec99a83.js                                     0.20 kB │ gzip:  0.18 kB
dist/assets/Dataset-83dfc999.js                                       0.20 kB │ gzip:  0.18 kB
dist/assets/Definitions-cc97a235.js                                   0.20 kB │ gzip:  0.18 kB
dist/assets/Annotations-8629414d.js                                   0.20 kB │ gzip:  0.18 kB
dist/assets/404-221249b7.js                                           0.70 kB │ gzip:  0.48 kB
dist/assets/Account-c36da6ac.js                                       0.82 kB │ gzip:  0.52 kB
dist/assets/Dashboard-5d147a91.js                                     2.25 kB │ gzip:  1.19 kB
dist/assets/Criteria-fbcf42c9.js                                      3.58 kB │ gzip:  1.47 kB
dist/assets/NavBar.vue_vue_type_script_setup_true_lang-d54c5c1c.js   37.33 kB │ gzip: 12.82 kB
dist/assets/index-9353f519.js                                       122.96 kB │ gzip: 48.09 kB
```